### PR TITLE
fix: 双向链接中插入空格导致链接失败

### DIFF
--- a/formatUtil.ts
+++ b/formatUtil.ts
@@ -107,7 +107,7 @@ export default {
     // 在 “中文English” 之间加入空格 “中文 English”
     // 在 “中文123” 之间加入空格 “中文 123”
     content = content.replace(
-      /(?<!\[.*\]\(.*)([\u4e00-\u9fa5\u3040-\u30FF])([a-zA-Z0-9`])/g,
+      /(?<!(?:\[.*\]\(.*)|(?:!?\[\[.*))([\u4e00-\u9fa5\u3040-\u30FF])([a-zA-Z0-9`])/g,
       '$1 $2'
     );
 
@@ -115,7 +115,7 @@ export default {
     // 在 “123中文” 之间加入空格 “123 中文”
     content = content.replace(
       /(?<!\[.*\]\(.*)([a-zA-Z0-9%`])([*]*[\u4e00-\u9fa5\u3040-\u30FF])/g,
-      '$1 $2'
+      "$1 $2"
     );
 
     // 在 「I said:it's a good news」的冒号与英文之间加入空格 「I said: it's a good news」

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+  rootDir: "./test",
+  transform: {
+    "^.+\\.tsx?$": "ts-jest", // 哪些文件需要用 ts-jest 执行
+  },
+  moduleFileExtensions: [
+    'ts',
+    'tsx',
+    'js',
+    'jsx',
+    'json',
+    'node',
+  ],
+  globals: {
+
+  },
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "rollup --config rollup.config.js -w",
     "build": "rollup --config rollup.config.js",
     "version": "auto-changelog -p && git add HISTORY.md",
-    "pub": "./pub.mjs"
+    "pub": "./pub.mjs",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -16,14 +17,16 @@
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
+    "@types/jest": "^28.1.1",
     "@types/node": "^14.14.2",
     "@types/pangu": "^3.3.0",
     "auto-changelog": "^2.3.0",
+    "jest": "^28.1.0",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.32.1",
     "semver": "^7.3.5",
+    "ts-jest": "^28.0.4",
     "tslib": "^2.0.3",
     "typescript": "^4.0.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/test/formatUtil.spec.ts
+++ b/test/formatUtil.spec.ts
@@ -1,0 +1,22 @@
+import formatUtil from '../formatUtil';
+describe('insertSpace test', () => {
+  const insertSpace = formatUtil.insertSpace
+
+  test('应该加空格', () => {
+    expect(insertSpace('定位wgs84')).toEqual('定位 wgs84');
+    expect(insertSpace('wgs84定位')).toEqual('wgs84 定位');
+    expect(insertSpace('[描述文本format](链接wgs84)')).toEqual('[描述文本 format](链接wgs84)');
+  });
+
+  test('不应该加空格', () => {
+    expect(insertSpace('![描述文本](wgs84链接wgs84)')).toEqual('![描述文本](wgs84链接wgs84)');
+    expect(insertSpace('[描述文本](wgs84链接wgs84)')).toEqual('[描述文本](wgs84链接wgs84)');
+    expect(insertSpace('[描述文本](链接wgs84)')).toEqual('[描述文本](链接wgs84)');
+
+    expect(insertSpace('[[本地文件wgd文件]]')).toEqual('[[本地文件wgd文件]]');
+    expect(insertSpace('[[wgd文件]]')).toEqual('[[wgd文件]]');
+
+    expect(insertSpace('![[本地文件wgd文件]]')).toEqual('![[本地文件wgd文件]]');
+    expect(insertSpace('![[wgd文件]]')).toEqual('![[wgd文件]]');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "esModuleInterop": true,
     "lib": [
       "dom",
       "es5",


### PR DESCRIPTION
fix issue #18 

增加双向绑定`[[`的正则匹配
增加`insertSpace`方法的单元测试